### PR TITLE
Fail-safe when naturalWidth is actually in width

### DIFF
--- a/lib/imageUtils.js
+++ b/lib/imageUtils.js
@@ -83,8 +83,8 @@ class CanvasUtil {
             ? createCanvas(sw || image.width, sh || image.height)
             : document.createElement("canvas");
 
-        canvas.width = image.naturalWidth || sw;
-        canvas.height = image.naturalHeight || sh;
+        canvas.width = image.naturalWidth || sw || image.width;
+        canvas.height = image.naturalHeight || sh || image.height;
 
         const ctx = canvas.getContext("2d");
 


### PR DESCRIPTION
I noticed I needed that to avoid failure. Might also be related to using canvas 3, or passing other params. I don't know.
Don't accept it without giving it more thought.